### PR TITLE
Update runtime to 6.9

### DIFF
--- a/io.github.xiaoyifang.goldendict_ng.json
+++ b/io.github.xiaoyifang.goldendict_ng.json
@@ -10,7 +10,7 @@
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
             "add-ld-path": ".",
-            "version": "24.08",
+            "version": "23.08",
             "no-autodownload": true,
             "autodelete": false
         }


### PR DESCRIPTION
anitya interprets the Debian versions of `eb` as pre-release, so I changed the x-checker-data to accommodate